### PR TITLE
Fix README links

### DIFF
--- a/bazarr/config.yaml
+++ b/bazarr/config.yaml
@@ -2,7 +2,7 @@ name: Bazarr
 version: 0.1.2
 slug: bazarr
 description: Download and manage subtitles for Sonarr and Radarr
-url: https://github.com/hassio-addons/addon-bazarr/tree/main/README.md
+url: https://github.com/hassio-addons/addon-bazarr/blob/main/README.md
 codenotary: codenotary@frenck.dev
 webui: http://[HOST]:[PORT:6767]
 init: false

--- a/lidarr/config.yaml
+++ b/lidarr/config.yaml
@@ -2,7 +2,7 @@ name: Lidarr
 version: 0.3.0
 slug: lidarr
 description: Looks and smells like Sonarr but made for music
-url: https://github.com/hassio-addons/addon-lidarr/tree/main/README.md
+url: https://github.com/hassio-addons/addon-lidarr/blob/main/README.md
 codenotary: codenotary@frenck.dev
 webui: http://[HOST]:[PORT:8686]
 init: false

--- a/overseerr/config.yaml
+++ b/overseerr/config.yaml
@@ -2,7 +2,7 @@ name: Overseerr
 version: 0.1.0
 slug: overseerr
 description: Request management and media discovery tool for the Plex ecosystem
-url: https://github.com/hassio-addons/addon-overseerr/tree/main/README.md
+url: https://github.com/hassio-addons/addon-overseerr/blob/main/README.md
 codenotary: codenotary@frenck.dev
 webui: http://[HOST]:[PORT:5055]
 init: false

--- a/prowlarr/config.yaml
+++ b/prowlarr/config.yaml
@@ -3,7 +3,7 @@ version: 0.6.0
 slug: prowlarr
 description: Indexer manager/proxy built on the popular arr stack to integrate with
   your various PVR apps
-url: https://github.com/hassio-addons/addon-prowlarr/tree/main/README.md
+url: https://github.com/hassio-addons/addon-prowlarr/blob/main/README.md
 codenotary: codenotary@frenck.dev
 webui: http://[HOST]:[PORT:9696]
 init: false

--- a/radarr/config.yaml
+++ b/radarr/config.yaml
@@ -2,7 +2,7 @@ name: Radarr
 version: 0.5.0
 slug: radarr
 description: Movie organizer/manager for usenet and torrent users
-url: https://github.com/hassio-addons/addon-radarr/tree/main/README.md
+url: https://github.com/hassio-addons/addon-radarr/blob/main/README.md
 codenotary: codenotary@frenck.dev
 webui: http://[HOST]:[PORT:7878]
 init: false

--- a/readarr/config.yaml
+++ b/readarr/config.yaml
@@ -2,7 +2,7 @@ name: Readarr
 version: 0.1.0
 slug: readarr
 description: Book Manager and Automation (Sonarr for Ebooks)
-url: https://github.com/hassio-addons/addon-readarr/tree/main/README.md
+url: https://github.com/hassio-addons/addon-readarr/blob/main/README.md
 codenotary: codenotary@frenck.dev
 webui: http://[HOST]:[PORT:8787]
 init: false

--- a/sabnzbd/config.yaml
+++ b/sabnzbd/config.yaml
@@ -2,7 +2,7 @@ name: SABnzbd
 version: 0.2.0
 slug: sabnzbd
 description: Free and easy binary newsreader
-url: https://github.com/hassio-addons/addon-sabnzbd/tree/main/README.md
+url: https://github.com/hassio-addons/addon-sabnzbd/blob/main/README.md
 codenotary: codenotary@frenck.dev
 ingress: true
 ingress_entry: sabnzbd/

--- a/sonarr/config.yaml
+++ b/sonarr/config.yaml
@@ -2,7 +2,7 @@ name: Sonarr
 version: 0.1.4
 slug: sonarr
 description: Smart PVR for newsgroup and bittorrent users
-url: https://github.com/hassio-addons/addon-sonarr/tree/main/README.md
+url: https://github.com/hassio-addons/addon-sonarr/blob/main/README.md
 codenotary: codenotary@frenck.dev
 webui: http://[HOST]:[PORT:8989]
 init: false

--- a/sqlite-web/config.yaml
+++ b/sqlite-web/config.yaml
@@ -2,7 +2,7 @@ name: SQLite Web
 version: 4.1.2
 slug: sqlite-web
 description: Explore your SQLite database
-url: https://github.com/hassio-addons/addon-sqlite-web/tree/main/README.md
+url: https://github.com/hassio-addons/addon-sqlite-web/blob/main/README.md
 codenotary: codenotary@frenck.dev
 ingress: true
 advanced: true

--- a/tautulli/config.yaml
+++ b/tautulli/config.yaml
@@ -2,7 +2,7 @@ name: Tautulli
 version: 4.0.1
 slug: tautulli
 description: Monitoring and tracking tool for Plex Media Server
-url: https://github.com/hassio-addons/addon-tautulli/tree/main/README.md
+url: https://github.com/hassio-addons/addon-tautulli/blob/main/README.md
 codenotary: codenotary@frenck.dev
 webui: '[PROTO:ssl]://[HOST]:[PORT:8181]'
 arch:

--- a/whisparr/config.yaml
+++ b/whisparr/config.yaml
@@ -3,7 +3,7 @@ version: 0.1.0
 slug: whisparr
 description: Whisparr is an adult video collection manager for Usenet and BitTorrent
   users
-url: https://github.com/hassio-addons/addon-whisparr/tree/main/README.md
+url: https://github.com/hassio-addons/addon-whisparr/blob/main/README.md
 codenotary: codenotary@frenck.dev
 webui: http://[HOST]:[PORT:6969]
 init: false


### PR DESCRIPTION
## Summary
- correct GitHub README URL paths in add-on configs

## Testing
- `bash build-site.sh`

------
https://chatgpt.com/codex/tasks/task_e_686245dac360832f9126e181b67af841