### PR TITLE
Add codespell step to lint workflow

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -14,3 +14,16 @@ on:
 jobs:
   workflows:
     uses: hassio-addons/workflows/.github/workflows/repository-lint.yaml@main
+
+  # Run codespell after the repository lint job to catch basic
+  # spelling mistakes. The job fails if any issues are detected.
+  codespell:
+    needs: workflows
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Spell check
+        uses: codespell-project/actions-codespell@v1
+        with:
+          check_filenames: true
+          check_hidden: true


### PR DESCRIPTION
## Summary
- run codespell as part of lint workflow

## Testing
- `codespell -q 3`

------
https://chatgpt.com/codex/tasks/task_e_686286d22748832fa530ff4b360764e5